### PR TITLE
feat: show loading title

### DIFF
--- a/src/pages/NewTop.css
+++ b/src/pages/NewTop.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=DotGothic16&display=swap');
+
 :root { --px-bg: #0b0d10; }
 
 .px-root {
@@ -67,10 +69,21 @@
 .px-press-overlay {
   position: fixed;
   inset: 0;
-  display: grid;
-  place-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 24px;
   z-index: 2;
   pointer-events: none;
+}
+
+.px-title {
+  pointer-events: none;
+  color: #e6e6e6;
+  font-family: 'DotGothic16', sans-serif;
+  font-size: 48px;
+  letter-spacing: 0.05em;
 }
 .px-press-label {
   pointer-events: none;

--- a/src/pages/NewTop.tsx
+++ b/src/pages/NewTop.tsx
@@ -381,6 +381,7 @@ export default function PixelSplitLanding({
       {/* PRESS ANY BUTTON overlay */}
       {awaitingPress && (
         <div className="px-press-overlay">
+          <div className="px-title">Napolin's Lab</div>
           <div className="px-press-label">PRESS ANY BUTTON</div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- display "Napolin's Lab" after loading line finishes
- load DotGothic16 font and style overlay layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: TypeError: Key "languageOptions": Key "globals": Global "AudioWorkletGlobalScope " has leading or trailing whitespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a7eff00634832fbc0a24045525a40c