### PR TITLE
feat: add dot-drop image reveal

### DIFF
--- a/src/pages/NewTop.tsx
+++ b/src/pages/NewTop.tsx
@@ -294,7 +294,7 @@ export default function PixelSplitLanding({
                 screenGrid.visible = true;
                 startReveal().then(() => {
                   sprite.visible = true;
-                  sprite.alpha = 0;
+                  sprite.alpha = 1;
                   interactionEnabled = true;
                   setIsLoaded(true);
                 });
@@ -364,6 +364,8 @@ export default function PixelSplitLanding({
           }
           if (done) {
             app.ticker.remove(step);
+            revealFx.visible = false;
+            revealFx.clear();
             resolve();
           }
         };

--- a/src/pages/NewTop.tsx
+++ b/src/pages/NewTop.tsx
@@ -293,7 +293,7 @@ export default function PixelSplitLanding({
               explodeTitle(() => {
                 setAwaitingPress(false);
                   screenGrid.visible = true;
-                  (imgData ? startReveal() : Promise.resolve()).then(() => {
+                  startReveal().then(() => {
                     interactionEnabled = true;
                     setIsLoaded(true);
                   });
@@ -311,24 +311,14 @@ export default function PixelSplitLanding({
       });
 
       // ===== 画像のアルファに沿ったホバー判定＋左右スウェイ =====
-      let imgData: Uint8ClampedArray | null = null;
-      const res = (tex.source as { resource?: { source?: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement } }).resource;
-      const srcEl: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | undefined = res?.source;
-      const texW = tex.source.width ?? 256;
-      const texH = tex.source.height ?? 256;
-      try {
-        if (srcEl) {
-          const off = document.createElement("canvas");
-          off.width = texW; off.height = texH;
-          const ictx = off.getContext("2d", { willReadFrequently: true })!;
-          ictx.imageSmoothingEnabled = false;
-          ictx.drawImage(srcEl, 0, 0, texW, texH);
-          imgData = ictx.getImageData(0, 0, texW, texH).data;
-        }
-      } catch { imgData = null; }
+      // texから画像データを取得
+      const texW = tex.width, texH = tex.height;
+      const imgData = app.renderer.extract.pixels(tex).pixels
 
       const startReveal = () => new Promise<void>((resolve) => {
+        console.log(imgData);
         const data = imgData!;
+        
         type Drop = { x:number; y:number; vx:number; vy:number; tx:number; ty:number; color:number; settled:boolean };
         const drops: Drop[] = [];
         for (let y = 0; y < texH; y++) {

--- a/src/pages/NewTop.tsx
+++ b/src/pages/NewTop.tsx
@@ -292,11 +292,11 @@ export default function PixelSplitLanding({
               if (onAnyPointer) { window.removeEventListener("pointerdown", onAnyPointer); onAnyPointer = null; }
               explodeTitle(() => {
                 setAwaitingPress(false);
-                screenGrid.visible = true;
-                startReveal().then(() => {
-                  interactionEnabled = true;
-                  setIsLoaded(true);
-                });
+                  screenGrid.visible = true;
+                  (imgData ? startReveal() : Promise.resolve()).then(() => {
+                    interactionEnabled = true;
+                    setIsLoaded(true);
+                  });
               });
             };
             onAnyKey = () => reveal();
@@ -328,15 +328,15 @@ export default function PixelSplitLanding({
       } catch { imgData = null; }
 
       const startReveal = () => new Promise<void>((resolve) => {
-        if (!imgData) { resolve(); return; }
+        const data = imgData!;
         type Drop = { x:number; y:number; vx:number; vy:number; tx:number; ty:number; color:number; settled:boolean };
         const drops: Drop[] = [];
         for (let y = 0; y < texH; y++) {
           for (let x = 0; x < texW; x++) {
             const idx = (y * texW + x) * 4;
-            const a = imgData[idx + 3];
+            const a = data[idx + 3];
             if (a > 16) {
-              const color = (imgData[idx] << 16) | (imgData[idx + 1] << 8) | imgData[idx + 2];
+              const color = (data[idx] << 16) | (data[idx + 1] << 8) | data[idx + 2];
               const x0 = texW / 2 + (Math.random() - 0.5) * texW;
               const y0 = -Math.random() * texH;
               drops.push({


### PR DESCRIPTION
## Summary
- animate image reveal using falling pixel particles in `NewTop`
- keep particle-based image layout responsive on window resize

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8224a0140832fb15e54a4a4550a9e