### PR TITLE
Refactor reveal effect to use pooled sprites

### DIFF
--- a/src/pages/NewTop.tsx
+++ b/src/pages/NewTop.tsx
@@ -1,6 +1,6 @@
 // PixelSplitLanding.tsx  (PixiJS v8 + external CSS)
 import React, { useEffect, useRef, useState } from "react";
-import { Application, Assets, Sprite, Texture, TextureStyle, Graphics, ParticleContainer, type IHitArea } from "pixi.js";
+import { Application, Assets, Sprite, Texture, TextureStyle, Graphics, ParticleContainer, Particle, type IHitArea } from "pixi.js";
 import "./NewTop.css";
 
 type Props = {
@@ -207,7 +207,7 @@ export default function PixelSplitLanding({
       revealFx.eventMode = "none";
       revealFx.visible = false;
       app.stage.addChild(revealFx);
-      const dropPool: Sprite[] = [];
+      const dropPool: Particle[] = [];
 
       // ドロー用オーバーレイ
       const dotFx = new Graphics();
@@ -346,18 +346,18 @@ export default function PixelSplitLanding({
           }
         }
         while (dropPool.length < drops.length) {
-          const s = new Sprite(Texture.WHITE);
-          s.width = 1;
-          s.height = 1;
-          dropPool.push(s);
-          revealFx.addParticle(s);
+          const p = new Particle(Texture.WHITE);
+          p.width = 1;
+          p.height = 1;
+          dropPool.push(p);
+          revealFx.addParticle(p);
         }
         for (let i = 0; i < drops.length; i++) {
-          const s = dropPool[i];
+          const p = dropPool[i];
           const d = drops[i];
-          s.visible = true;
-          s.position.set(Math.floor(d.x), Math.floor(d.y));
-          s.tint = d.color;
+          p.visible = true;
+          p.position.set(Math.floor(d.x), Math.floor(d.y));
+          p.tint = d.color;
         }
         for (let i = drops.length; i < dropPool.length; i++) {
           dropPool[i].visible = false;
@@ -391,8 +391,8 @@ export default function PixelSplitLanding({
                 }
               }
             }
-            const s = dropPool[i];
-            s.position.set(Math.floor(d.x), Math.floor(d.y));
+            const p = dropPool[i];
+            p.position.set(Math.floor(d.x), Math.floor(d.y));
           }
           if (allSettled) {
             app.ticker.remove(step);

--- a/src/pages/NewTop.tsx
+++ b/src/pages/NewTop.tsx
@@ -1,6 +1,6 @@
 // PixelSplitLanding.tsx  (PixiJS v8 + external CSS)
 import React, { useEffect, useRef, useState } from "react";
-import { Application, Assets, Sprite, TextureStyle, Graphics, type IHitArea } from "pixi.js";
+import { Application, Assets, Sprite, Texture, TextureStyle, Graphics, ParticleContainer, type IHitArea } from "pixi.js";
 import "./NewTop.css";
 
 type Props = {
@@ -200,10 +200,11 @@ export default function PixelSplitLanding({
       app.stage.addChild(loaderFx);
 
       // 画像形成用レイヤ
-      const revealFx = new Graphics();
+      const revealFx = new ParticleContainer(undefined, { position: true, tint: true });
       revealFx.eventMode = "none";
       revealFx.visible = false;
       app.stage.addChild(revealFx);
+      const dropPool: Sprite[] = [];
 
       // ドロー用オーバーレイ
       const dotFx = new Graphics();
@@ -316,9 +317,8 @@ export default function PixelSplitLanding({
       const imgData = app.renderer.extract.pixels(tex).pixels
 
       const startReveal = () => new Promise<void>((resolve) => {
-        console.log(imgData);
         const data = imgData!;
-        
+
         type Drop = { x:number; y:number; vx:number; vy:number; tx:number; ty:number; color:number; settled:boolean };
         const drops: Drop[] = [];
         for (let y = 0; y < texH; y++) {
@@ -342,13 +342,30 @@ export default function PixelSplitLanding({
             }
           }
         }
+        while (dropPool.length < drops.length) {
+          const s = new Sprite(Texture.WHITE);
+          s.width = 1;
+          s.height = 1;
+          dropPool.push(s);
+          revealFx.addChild(s);
+        }
+        for (let i = 0; i < drops.length; i++) {
+          const s = dropPool[i];
+          const d = drops[i];
+          s.visible = true;
+          s.position.set(Math.floor(d.x), Math.floor(d.y));
+          s.tint = d.color;
+        }
+        for (let i = drops.length; i < dropPool.length; i++) {
+          dropPool[i].visible = false;
+        }
         revealFx.visible = true;
         const g = texH * 0.75; // 重力加速度(px/s^2)
         const step = () => {
           const dt = app.ticker.deltaMS / 1000;
           let allSettled = true;
-          revealFx.clear();
-          for (const d of drops) {
+          for (let i = 0; i < drops.length; i++) {
+            const d = drops[i];
             if (!d.settled) {
               allSettled = false;
               d.vy += g * dt;
@@ -371,7 +388,8 @@ export default function PixelSplitLanding({
                 }
               }
             }
-            revealFx.rect(Math.floor(d.x), Math.floor(d.y), 1, 1).fill(d.color);
+            const s = dropPool[i];
+            s.position.set(Math.floor(d.x), Math.floor(d.y));
           }
           if (allSettled) {
             app.ticker.remove(step);

--- a/src/pages/NewTop.tsx
+++ b/src/pages/NewTop.tsx
@@ -200,7 +200,10 @@ export default function PixelSplitLanding({
       app.stage.addChild(loaderFx);
 
       // 画像形成用レイヤ
-      const revealFx = new ParticleContainer(undefined, { position: true, tint: true });
+      const revealFx = new ParticleContainer({
+        autoResize: true,
+        properties: { position: true, tint: true },
+      });
       revealFx.eventMode = "none";
       revealFx.visible = false;
       app.stage.addChild(revealFx);

--- a/src/pages/NewTop.tsx
+++ b/src/pages/NewTop.tsx
@@ -350,7 +350,7 @@ export default function PixelSplitLanding({
           s.width = 1;
           s.height = 1;
           dropPool.push(s);
-          revealFx.addChild(s);
+          revealFx.addParticle(s);
         }
         for (let i = 0; i < drops.length; i++) {
           const s = dropPool[i];


### PR DESCRIPTION
## Summary
- Replace Graphics-based pixel reveal with a ParticleContainer and pooled 1x1 sprites
- Update reveal animation loop to move and tint sprites, enabling batched draw calls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a89c0749b0832f9ffe270988ba1844